### PR TITLE
Add documentation and tests for builtins.go

### DIFF
--- a/mg/builtins.go
+++ b/mg/builtins.go
@@ -112,6 +112,8 @@ func (bc BuiltinCmds) Commands() BultinCmdList {
 	}
 }
 
+// Reduce will return a copy of the mx.State while adding the predefined
+// commands to its builtins, if the mx.Action is a RunCmd.
 func (bc BuiltinCmds) Reduce(mx *Ctx) *State {
 	if _, ok := mx.Action.(RunCmd); ok {
 		return mx.State.AddBuiltinCmds(bc.Commands()...)

--- a/mg/builtins.go
+++ b/mg/builtins.go
@@ -3,10 +3,9 @@ package mg
 import (
 	"bytes"
 	"fmt"
+	"margo.sh/mgutil"
 	"os"
 	"sort"
-
-	"margo.sh/mgutil"
 )
 
 var (
@@ -32,13 +31,10 @@ func (bcl BultinCmdList) Lookup(name string) (cmd BultinCmd, found bool) {
 	panic("internal error: the `.exec` BuiltinCmd is not defined")
 }
 
-// BuiltinCmds is used to add a list of predefined commands to the state. It
-// implements Reducer interface.
+// BuiltinCmds implements various builtin commands.
 type BuiltinCmds struct{}
 
-// ExecCmd spawns the given command in a goroutine and returns its State right
-// away. If the name is `.exec`, it will use its first argument as the `Name`
-// and the rest of the args for the `Args`.
+// ExecCmd implements the `.exec` builtin.
 func (bc BuiltinCmds) ExecCmd(bx *BultinCmdCtx) *State {
 	go execCmd(bx)
 	return bx.State
@@ -90,7 +86,7 @@ func EnvCmd(bx *BultinCmdCtx) *State {
 	names := bx.Args
 	if len(names) == 0 {
 		names = make([]string, 0, len(bx.Env))
-		for k := range bx.Env {
+		for k, _ := range bx.Env {
 			names = append(names, k)
 		}
 		sort.Strings(names)
@@ -112,8 +108,7 @@ func (bc BuiltinCmds) Commands() BultinCmdList {
 	}
 }
 
-// Reduce will return a copy of the mx.State while adding the predefined
-// commands to its builtins, if the mx.Action is a RunCmd.
+// Reduce adds the list of predefined builtins for the RunCmd.
 func (bc BuiltinCmds) Reduce(mx *Ctx) *State {
 	if _, ok := mx.Action.(RunCmd); ok {
 		return mx.State.AddBuiltinCmds(bc.Commands()...)

--- a/mg/builtins.go
+++ b/mg/builtins.go
@@ -36,11 +36,11 @@ type BuiltinCmds struct{}
 
 // ExecCmd implements the `.exec` builtin.
 func (bc BuiltinCmds) ExecCmd(bx *BultinCmdCtx) *State {
-	go execCmd(bx)
+	go bc.execCmd(bx)
 	return bx.State
 }
 
-func execCmd(bx *BultinCmdCtx) {
+func (bc BuiltinCmds) execCmd(bx *BultinCmdCtx) {
 	defer bx.Output.Close()
 
 	if bx.Name == ".exec" {
@@ -59,7 +59,7 @@ func execCmd(bx *BultinCmdCtx) {
 // TypeCmd tries to find the bx.Args in commands, and writes the description of
 // the commands into provided buffer. If the Args is empty, it uses all
 // available commands.
-func TypeCmd(bx *BultinCmdCtx) *State {
+func (bc BuiltinCmds) TypeCmd(bx *BultinCmdCtx) *State {
 	cmds := bx.BuiltinCmds
 	names := bx.Args
 	if len(names) == 0 {
@@ -81,7 +81,7 @@ func TypeCmd(bx *BultinCmdCtx) *State {
 
 // EnvCmd finds all environment variables corresponding to bx.Args into the
 // bx.Output buffer.
-func EnvCmd(bx *BultinCmdCtx) *State {
+func (bc BuiltinCmds) EnvCmd(bx *BultinCmdCtx) *State {
 	buf := &bytes.Buffer{}
 	names := bx.Args
 	if len(names) == 0 {
@@ -102,9 +102,9 @@ func EnvCmd(bx *BultinCmdCtx) *State {
 // Commands returns a list of predefined commands.
 func (bc BuiltinCmds) Commands() BultinCmdList {
 	return []BultinCmd{
-		BultinCmd{Name: ".env", Desc: "List env vars", Run: EnvCmd},
+		BultinCmd{Name: ".env", Desc: "List env vars", Run: bc.EnvCmd},
 		BultinCmd{Name: ".exec", Desc: "Run a command through os/exec", Run: bc.ExecCmd},
-		BultinCmd{Name: ".type", Desc: "Lists all builtins or which builtin handles a command", Run: TypeCmd},
+		BultinCmd{Name: ".type", Desc: "Lists all builtins or which builtin handles a command", Run: bc.TypeCmd},
 	}
 }
 

--- a/mg/builtins.go
+++ b/mg/builtins.go
@@ -83,12 +83,14 @@ func TypeCmd(bx *BultinCmdCtx) *State {
 	return bx.State
 }
 
+// EnvCmd finds all environment variables corresponding to bx.Args into the
+// bx.Output buffer.
 func EnvCmd(bx *BultinCmdCtx) *State {
 	buf := &bytes.Buffer{}
 	names := bx.Args
 	if len(names) == 0 {
 		names = make([]string, 0, len(bx.Env))
-		for k, _ := range bx.Env {
+		for k := range bx.Env {
 			names = append(names, k)
 		}
 		sort.Strings(names)

--- a/mg/builtins_test.go
+++ b/mg/builtins_test.go
@@ -1,0 +1,114 @@
+package mg_test
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+
+	"margo.sh/mg"
+)
+
+func TestBultinCmdList_Lookup(t *testing.T) {
+	exec := func() mg.BultinCmd {
+		r, _ := mg.Builtins.Commands().Lookup(".exec")
+		return r
+	}()
+	item := mg.BultinCmd{
+		Name: "this name",
+		Desc: "description",
+		Run:  func(*mg.BultinCmdCtx) *mg.State { return nil },
+	}
+	tcs := []struct {
+		name      string
+		bcl       mg.BultinCmdList
+		input     string
+		wantCmd   mg.BultinCmd
+		wantFound bool
+	}{
+		{"empty cmd list", mg.BultinCmdList{}, "nothing to find", exec, false},
+		{"not found", mg.BultinCmdList{item}, "not found", exec, false},
+		{"found", mg.BultinCmdList{item}, item.Name, item, true},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			gotCmd, gotFound := tc.bcl.Lookup(tc.input)
+			// there is no way to compare functions, therefore we just check the names.
+			if gotCmd.Name != tc.wantCmd.Name {
+				t.Errorf("Lookup(): gotCmd = (%v); want (%v)", gotCmd, tc.wantCmd)
+			}
+			if gotFound != tc.wantFound {
+				t.Errorf("Lookup(): gotFound = (%v); want (%v)", gotFound, tc.wantFound)
+			}
+		})
+	}
+}
+
+// tests when the Args is empty, it should pick up the available BuiltinCmd(s).
+func TestTypeCmdEmptyArgs(t *testing.T) {
+	item1 := mg.BultinCmd{Name: "this name", Desc: "this description"}
+	item2 := mg.BultinCmd{Name: "another one", Desc: "should appear too"}
+	buf := new(bytes.Buffer)
+	input := &mg.BultinCmdCtx{
+		Ctx: &mg.Ctx{
+			State: &mg.State{
+				BuiltinCmds: mg.BultinCmdList{item1, item2},
+			},
+		},
+		Output: &mg.CmdOutputWriter{
+			Writer:   buf,
+			Dispatch: nil,
+		},
+	}
+
+	if got := mg.TypeCmd(input); !reflect.DeepEqual(got, input.State) {
+		t.Errorf("TypeCmd() = %v, want %v", got, input.State)
+	}
+	out := buf.String()
+	for _, item := range []mg.BultinCmd{item1, item2} {
+		if !strings.Contains(out, item.Name) {
+			t.Errorf("buf.String() = (%s); want (%s) in it", out, item.Name)
+		}
+		if !strings.Contains(out, item.Desc) {
+			t.Errorf("buf.String() = (%s); want (%s) in it", out, item.Desc)
+		}
+	}
+}
+
+// tests when command is found, it should choose it.
+func TestTypeCmdLookupCmd(t *testing.T) {
+	item1 := mg.BultinCmd{Name: "this name", Desc: "this description"}
+	item2 := mg.BultinCmd{Name: "another one", Desc: "should not appear"}
+	buf := new(bytes.Buffer)
+	input := &mg.BultinCmdCtx{
+		Ctx: &mg.Ctx{
+			State: &mg.State{
+				BuiltinCmds: mg.BultinCmdList{item1, item2},
+			},
+		},
+		Output: &mg.CmdOutputWriter{
+			Writer:   buf,
+			Dispatch: nil,
+		},
+		RunCmd: mg.RunCmd{
+			Args: []string{item2.Name},
+		},
+	}
+
+	if got := mg.TypeCmd(input); !reflect.DeepEqual(got, input.State) {
+		t.Errorf("TypeCmd() = %v, want %v", got, input.State)
+	}
+	out := buf.String()
+	if strings.Contains(out, item1.Name) {
+		t.Errorf("buf.String() = (%s); didn't expect (%s) in it", out, item1.Name)
+	}
+	if strings.Contains(out, item1.Name) {
+		t.Errorf("buf.String() = (%s); didn't expect (%s) in it", out, item1.Name)
+	}
+	if !strings.Contains(out, item2.Name) {
+		t.Errorf("buf.String() = (%s); want (%s) in it", out, item2.Name)
+	}
+	if !strings.Contains(out, item2.Name) {
+		t.Errorf("buf.String() = (%s); want (%s) in it", out, item2.Name)
+	}
+}

--- a/mg/builtins_test.go
+++ b/mg/builtins_test.go
@@ -86,16 +86,13 @@ func buildBultinCmdCtx(cmds mg.BultinCmdList, args []string, envMap mg.EnvMap, b
 		},
 	}
 	ctx.Env = envMap
-	return &mg.BultinCmdCtx{
-		Ctx: ctx,
-		Output: &mg.CmdOutputWriter{
-			Writer:   buf,
-			Dispatch: nil,
-		},
-		RunCmd: mg.RunCmd{
-			Args: args,
-		},
+	rc := mg.RunCmd{Args: args}
+	cmd := mg.NewBultinCmdCtx(ctx, rc)
+	cmd.Output = &mg.CmdOutputWriter{
+		Writer:   buf,
+		Dispatch: nil,
 	}
+	return cmd
 }
 
 // tests when command is found, it should choose it.

--- a/mg/builtins_test.go
+++ b/mg/builtins_test.go
@@ -202,3 +202,50 @@ func TestEnvCmd(t *testing.T) {
 		})
 	}
 }
+
+func TestBuiltinCmdsReduce(t *testing.T) {
+	t.Parallel()
+	isIn := func(cmd mg.BultinCmd, haystack mg.BultinCmdList) bool {
+		for _, h := range haystack {
+			if h.Name == cmd.Name && h.Desc == cmd.Desc {
+				return true
+			}
+		}
+		return false
+	}
+
+	item := mg.BultinCmd{Name: "qNgEYow", Desc: "YKjYxqMnt"}
+	ctx := &mg.Ctx{
+		State: &mg.State{
+			BuiltinCmds: mg.BultinCmdList{item},
+		},
+	}
+
+	bc := mg.BuiltinCmds{}
+	state := bc.Reduce(ctx)
+	if state == nil {
+		t.Fatal("bc.Reduce() = nil, want *State")
+	}
+	for _, cmd := range bc.Commands() {
+		if isIn(cmd, state.BuiltinCmds) {
+			t.Errorf("didn't want %v in %v", cmd, bc.Commands())
+		}
+	}
+	if !isIn(item, state.BuiltinCmds) {
+		t.Errorf("want %v in %v", item, bc.Commands())
+	}
+
+	ctx.Action = mg.RunCmd{}
+	state = bc.Reduce(ctx)
+	if state == nil {
+		t.Fatal("bc.Reduce() = nil, want *State")
+	}
+	for _, cmd := range bc.Commands() {
+		if !isIn(cmd, state.BuiltinCmds) {
+			t.Errorf("want %v in %v", cmd, bc.Commands())
+		}
+	}
+	if !isIn(item, state.BuiltinCmds) {
+		t.Errorf("want %v in %v", item, bc.Commands())
+	}
+}

--- a/mg/builtins_test.go
+++ b/mg/builtins_test.go
@@ -64,7 +64,7 @@ func TestTypeCmdEmptyArgs(t *testing.T) {
 		},
 	}
 
-	if got := mg.TypeCmd(input); got != input.State {
+	if got := mg.Builtins.TypeCmd(input); got != input.State {
 		t.Errorf("TypeCmd() = %v, want %v", got, input.State)
 	}
 	out := buf.String()
@@ -104,7 +104,7 @@ func TestTypeCmdLookupCmd(t *testing.T) {
 	input, cleanup := setupBultinCmdCtx(mg.BultinCmdList{item1, item2}, []string{item2.Name}, nil, buf)
 	defer cleanup()
 
-	if got := mg.TypeCmd(input); got != input.State {
+	if got := mg.Builtins.TypeCmd(input); got != input.State {
 		t.Errorf("TypeCmd() = %v, want %v", got, input.State)
 	}
 	out := buf.String()
@@ -186,7 +186,7 @@ func TestEnvCmd(t *testing.T) {
 			buf := new(bytes.Buffer)
 			input, cleanup := setupBultinCmdCtx(tc.cmds, tc.args, tc.envs, buf)
 			defer cleanup()
-			if got := mg.EnvCmd(input); got == nil {
+			if got := mg.Builtins.EnvCmd(input); got == nil {
 				t.Error("EnvCmd() = (nil); want (*State)")
 			}
 			out := buf.String()


### PR DESCRIPTION
It changes `TypeCmd` and `EnvCmd` to functions as they are not changing the state of `BuiltinCmds` values. `ExecCmd` probably should be a function too but it was used [here](https://github.com/KurokuLabs/margo/blob/master/mg/cmd.go#L125) so I didn't touch it.