### PR TITLE
Development

### DIFF
--- a/extension-example/extension-example.go
+++ b/extension-example/extension-example.go
@@ -156,7 +156,7 @@ type DayTimeStatus struct {
 	mg.ReducerType
 }
 
-func (dts DayTimeStatus) ReducerMount(mx *mg.Ctx) {
+func (dts DayTimeStatus) ReMount(mx *mg.Ctx) {
 	// kick off the ticker when we start
 	dispatch := mx.Store.Dispatch
 	go func() {

--- a/golang/gocode.go
+++ b/golang/gocode.go
@@ -75,7 +75,7 @@ type Gocode struct {
 	reqs chan gocodeReq
 }
 
-func (g *Gocode) ReducerConfig(mx *mg.Ctx) mg.EditorConfig {
+func (g *Gocode) ReEditorConfig(mx *mg.Ctx) mg.EditorConfig {
 	cfg, ok := mx.Config.(sublime.Config)
 	if !ok {
 		return nil
@@ -84,7 +84,7 @@ func (g *Gocode) ReducerConfig(mx *mg.Ctx) mg.EditorConfig {
 	// ST might query the GoSublime plugin first, so we must always disable it
 	cfg = cfg.DisableGsComplete()
 	// but we don't want to affect editor completions in non-go files
-	if !g.ReducerCond(mx) {
+	if !g.ReCond(mx) {
 		return cfg
 	}
 
@@ -97,11 +97,11 @@ func (g *Gocode) ReducerConfig(mx *mg.Ctx) mg.EditorConfig {
 	return cfg
 }
 
-func (g *Gocode) ReducerCond(mx *mg.Ctx) bool {
+func (g *Gocode) ReCond(mx *mg.Ctx) bool {
 	return mx.ActionIs(mg.QueryCompletions{}) && mx.LangIs(mg.Go)
 }
 
-func (g *Gocode) ReducerMount(mx *mg.Ctx) {
+func (g *Gocode) ReMount(mx *mg.Ctx) {
 	g.reqs = make(chan gocodeReq)
 	go func() {
 		for gr := range g.reqs {
@@ -110,7 +110,7 @@ func (g *Gocode) ReducerMount(mx *mg.Ctx) {
 	}()
 }
 
-func (g *Gocode) ReducerUnmount(mx *mg.Ctx) {
+func (g *Gocode) ReUnmount(mx *mg.Ctx) {
 	close(g.reqs)
 }
 

--- a/golang/gocode_calltips.go
+++ b/golang/gocode_calltips.go
@@ -32,16 +32,16 @@ type GocodeCalltips struct {
 	status string
 }
 
-func (gc *GocodeCalltips) ReducerCond(mx *mg.Ctx) bool {
+func (gc *GocodeCalltips) ReCond(mx *mg.Ctx) bool {
 	return mx.LangIs(mg.Go)
 }
 
-func (gc *GocodeCalltips) ReducerMount(mx *mg.Ctx) {
+func (gc *GocodeCalltips) ReMount(mx *mg.Ctx) {
 	gc.q = mgutil.NewChanQ(1)
 	go gc.processer()
 }
 
-func (gc *GocodeCalltips) ReducerUnmount(mx *mg.Ctx) {
+func (gc *GocodeCalltips) ReUnmount(mx *mg.Ctx) {
 	gc.q.Close()
 }
 

--- a/golang/gotest.go
+++ b/golang/gotest.go
@@ -22,7 +22,7 @@ type TestCmds struct {
 	TestArgs []string
 }
 
-func (tc *TestCmds) ReducerCond(mx *mg.Ctx) bool {
+func (tc *TestCmds) ReCond(mx *mg.Ctx) bool {
 	return mx.LangIs(mg.Go)
 }
 

--- a/golang/guru.go
+++ b/golang/guru.go
@@ -25,11 +25,11 @@ type Guru struct {
 	mg.ReducerType
 }
 
-func (g *Guru) ReducerCond(mx *mg.Ctx) bool {
+func (g *Guru) ReCond(mx *mg.Ctx) bool {
 	return mx.LangIs(mg.Go)
 }
 
-func (g *Guru) ReducerMount(mx *mg.Ctx) {
+func (g *Guru) ReMount(mx *mg.Ctx) {
 	go cmdrunner.Cmd{
 		Name:     "go",
 		Args:     []string{"install", "margo.sh/vendor/golang.org/x/tools/cmd/guru"},

--- a/golang/lint.go
+++ b/golang/lint.go
@@ -20,8 +20,8 @@ type Linter struct {
 	TempDir []string
 }
 
-// ReducerInit syncs top-level fields with the underlying Linter
-func (lt *Linter) ReducerInit(mx *mg.Ctx) {
+// ReInit syncs top-level fields with the underlying Linter
+func (lt *Linter) ReInit(mx *mg.Ctx) {
 	l := &lt.Linter
 	l.Actions = lt.Actions
 	l.Name = lt.Name
@@ -30,12 +30,12 @@ func (lt *Linter) ReducerInit(mx *mg.Ctx) {
 	l.Label = lt.Label
 	l.TempDir = lt.TempDir
 
-	lt.Linter.ReducerInit(mx)
+	lt.Linter.ReInit(mx)
 }
 
-// ReducerCond restricts reduction to Go
-func (lt *Linter) ReducerCond(mx *mg.Ctx) bool {
-	return mx.LangIs(mg.Go) && lt.Linter.ReducerCond(mx)
+// ReCond restricts reduction to Go
+func (lt *Linter) ReCond(mx *mg.Ctx) bool {
+	return mx.LangIs(mg.Go) && lt.Linter.ReCond(mx)
 }
 
 // GoInstall returns a Linter that runs `go install args...`

--- a/golang/margocode.go
+++ b/golang/margocode.go
@@ -364,7 +364,7 @@ type MarGocodeCtl struct {
 	ImporterMode ImporterMode
 }
 
-func (mgc *MarGocodeCtl) ReducerInit(mx *mg.Ctx) {
+func (mgc *MarGocodeCtl) ReInit(mx *mg.Ctx) {
 	mctl.conf(mx, mgc)
 }
 

--- a/golang/snippets.go
+++ b/golang/snippets.go
@@ -34,7 +34,7 @@ func SnippetFuncs(l ...SnippetFunc) *SnippetFuncsList {
 	return &SnippetFuncsList{Funcs: l}
 }
 
-func (sf *SnippetFuncsList) ReducerCond(mx *mg.Ctx) bool {
+func (sf *SnippetFuncsList) ReCond(mx *mg.Ctx) bool {
 	return mx.ActionIs(mg.QueryCompletions{}) && mx.LangIs(mg.Go)
 }
 

--- a/golang/syntaxcheck.go
+++ b/golang/syntaxcheck.go
@@ -12,16 +12,16 @@ type SyntaxCheck struct {
 	q *mgutil.ChanQ
 }
 
-func (sc *SyntaxCheck) ReducerCond(mx *mg.Ctx) bool {
+func (sc *SyntaxCheck) ReCond(mx *mg.Ctx) bool {
 	return mx.LangIs(mg.Go)
 }
 
-func (sc *SyntaxCheck) ReducerMount(mx *mg.Ctx) {
+func (sc *SyntaxCheck) ReMount(mx *mg.Ctx) {
 	sc.q = mgutil.NewChanQ(1)
 	go sc.checker()
 }
 
-func (sc *SyntaxCheck) ReducerUnmount(mx *mg.Ctx) {
+func (sc *SyntaxCheck) ReUnmount(mx *mg.Ctx) {
 	sc.q.Close()
 }
 

--- a/js/jsonfmt.go
+++ b/js/jsonfmt.go
@@ -12,7 +12,7 @@ type JsonFmt struct {
 	Indent string
 }
 
-func (j JsonFmt) ReducerCond(mx *mg.Ctx) bool {
+func (j JsonFmt) ReCond(mx *mg.Ctx) bool {
 	return mx.ActionIs(mg.ViewFmt{}) && mx.LangIs(mg.JSON)
 }
 

--- a/mg/cmd.go
+++ b/mg/cmd.go
@@ -242,7 +242,7 @@ func (osr *outputStreamRef) Close() error {
 	return nil
 }
 
-type RunCmdData struct {
+type runCmdData struct {
 	*Ctx
 	RunCmd
 }
@@ -256,6 +256,7 @@ func (fs RunCmdFlagSet) Parse() error {
 	return fs.FlagSet.Parse(fs.RunCmd.Args)
 }
 
+type RunDmc = RunCmd
 type RunCmd struct {
 	ActionType
 
@@ -296,7 +297,7 @@ func (rc RunCmd) IntFlag(name string, value int) int {
 }
 
 func (rc RunCmd) Interpolate(mx *Ctx) RunCmd {
-	data := RunCmdData{
+	data := runCmdData{
 		Ctx:    mx,
 		RunCmd: rc,
 	}
@@ -309,7 +310,7 @@ func (rc RunCmd) Interpolate(mx *Ctx) RunCmd {
 	return rc
 }
 
-func (rc RunCmd) interp(data RunCmdData, tpl *template.Template, buf *bytes.Buffer, s string) string {
+func (rc RunCmd) interp(data runCmdData, tpl *template.Template, buf *bytes.Buffer, s string) string {
 	if strings.Contains(s, "{{") && strings.Contains(s, "}}") {
 		if tpl, err := tpl.Parse(s); err == nil {
 			buf.Reset()

--- a/mg/issue.go
+++ b/mg/issue.go
@@ -179,7 +179,7 @@ type issueKeySupport struct {
 	issues map[IssueKey]IssueSet
 }
 
-func (iks *issueKeySupport) ReducerMount(mx *Ctx) {
+func (iks *issueKeySupport) ReMount(mx *Ctx) {
 	iks.issues = map[IssueKey]IssueSet{}
 }
 

--- a/mg/lint.go
+++ b/mg/lint.go
@@ -23,7 +23,7 @@ type Linter struct {
 	q *mgutil.ChanQ
 }
 
-func (lt *Linter) ReducerCond(mx *Ctx) bool {
+func (lt *Linter) ReCond(mx *Ctx) bool {
 	return mx.LangIs(lt.Langs...) &&
 		(mx.ActionIs(lt.userActs()...) || mx.ActionIs(lt.auxActs()...))
 }
@@ -50,12 +50,12 @@ func (lt *Linter) Reduce(mx *Ctx) *State {
 	}
 }
 
-func (lt *Linter) ReducerMount(mx *Ctx) {
+func (lt *Linter) ReMount(mx *Ctx) {
 	lt.q = mgutil.NewChanQ(1)
 	go lt.loop()
 }
 
-func (lt *Linter) ReducerUnmount(mx *Ctx) {
+func (lt *Linter) ReUnmount(mx *Ctx) {
 	lt.q.Close()
 }
 

--- a/mg/motd.go
+++ b/mg/motd.go
@@ -76,17 +76,17 @@ type MOTD struct {
 	mu sync.Mutex
 }
 
-func (m *MOTD) ReducerInit(mx *Ctx) {
+func (m *MOTD) ReInit(mx *Ctx) {
 	if m.Endpoint == "" {
 		m.Endpoint = "https://api.margo.sh/motd.json"
 	}
 }
 
-func (m *MOTD) ReducerCond(mx *Ctx) bool {
+func (m *MOTD) ReCond(mx *Ctx) bool {
 	return mx.Editor.Ready()
 }
 
-func (m *MOTD) ReducerMount(mx *Ctx) {
+func (m *MOTD) ReMount(mx *Ctx) {
 	go m.proc(mx)
 }
 

--- a/mg/restart.go
+++ b/mg/restart.go
@@ -21,15 +21,15 @@ type restartSupport struct {
 	issues IssueSet
 }
 
-func (rs *restartSupport) ReducerLabel() string {
+func (rs *restartSupport) ReLabel() string {
 	return "Mg/Restart"
 }
 
-func (rs *restartSupport) ReducerInit(mx *Ctx) {
+func (rs *restartSupport) ReInit(mx *Ctx) {
 	go rs.onInit(mx)
 }
 
-func (rs *restartSupport) ReducerCond(mx *Ctx) bool {
+func (rs *restartSupport) ReCond(mx *Ctx) bool {
 	if len(rs.issues) != 0 || mx.ActionIs(rsIssues{}) {
 		return true
 	}
@@ -39,12 +39,12 @@ func (rs *restartSupport) ReducerCond(mx *Ctx) bool {
 	return false
 }
 
-func (rs *restartSupport) ReducerMount(mx *Ctx) {
+func (rs *restartSupport) ReMount(mx *Ctx) {
 	rs.q = mgutil.NewChanQ(1)
 	go rs.loop()
 }
 
-func (rs *restartSupport) ReducerUnmount(mx *Ctx) {
+func (rs *restartSupport) ReUnmount(mx *Ctx) {
 	rs.q.Close()
 }
 
@@ -136,14 +136,14 @@ func (rs *restartSupport) slowLint(mx *Ctx, pkg *build.Package) IssueSet {
 	isuOut := &IssueOut{
 		Dir:      mx.View.Dir(),
 		Patterns: mx.CommonPatterns(),
-		Base:     Issue{Label: rs.ReducerLabel()},
+		Base:     Issue{Label: rs.ReLabel()},
 	}
 	isuOut.Write(output)
 	isuOut.Close()
 	issues := isuOut.Issues()
 
 	if err != nil {
-		mx.Log.Printf(rs.ReducerLabel()+": %s\n%s\n", err, output)
+		mx.Log.Printf(rs.ReLabel()+": %s\n%s\n", err, output)
 	}
 	return issues
 }

--- a/mg/state.go
+++ b/mg/state.go
@@ -37,7 +37,7 @@ type EditorProps struct {
 
 // Ready returns true if the editor state has synced
 //
-// Reducers use this method in their ReducerCond to avoid mounting until
+// Reducers can call Ready in their ReCond method to avoid mounting until
 // the editor has communicated its state.
 // Before the editor is ready, State.View, State.Editor, etc. might not contain usable data.
 func (ep *EditorProps) Ready() bool {

--- a/mg/tasks.go
+++ b/mg/tasks.go
@@ -54,7 +54,7 @@ type taskTracker struct {
 	buf     bytes.Buffer
 }
 
-func (tr *taskTracker) ReducerMount(mx *Ctx) {
+func (tr *taskTracker) ReMount(mx *Ctx) {
 	tr.mu.Lock()
 	defer tr.mu.Unlock()
 
@@ -67,7 +67,7 @@ func (tr *taskTracker) ReducerMount(mx *Ctx) {
 	}()
 }
 
-func (tr *taskTracker) ReducerUnmount(*Ctx) {
+func (tr *taskTracker) ReUnmount(*Ctx) {
 	tr.mu.Lock()
 	defer tr.mu.Unlock()
 

--- a/web/nodejs/packagescripts.go
+++ b/web/nodejs/packagescripts.go
@@ -19,11 +19,11 @@ type PackageScripts struct {
 	Cmd string
 }
 
-func (ps *PackageScripts) ReducerCond(mx *mg.Ctx) bool {
+func (ps *PackageScripts) ReCond(mx *mg.Ctx) bool {
 	return mx.ActionIs(mg.QueryUserCmds{})
 }
 
-func (ps *PackageScripts) ReducerMount(mx *mg.Ctx) {
+func (ps *PackageScripts) ReMount(mx *mg.Ctx) {
 	if ps.Cmd == "" {
 		ps.Cmd = ps.yarnOrNPM()
 	}


### PR DESCRIPTION

* API BREAKAGE: Rename mg.Reducer.Reducer* to mg.Reducer.Re*:
  * ReducerLabel -> ReLabel
  * ReducerInit -> ReInit
  * ReducerConfig -> ReEditorConfig
  * ReducerCond -> ReCond
  * ReducerMount -> ReMount
  * Reducerduce -> Reduce
  * ReducerUnmount -> ReUnmount

* API BREAKAGE: mg.RunCmdData has been un-exported

