### PR TITLE
misc improvements to the gocode reducers

### DIFF
--- a/golang/common.go
+++ b/golang/common.go
@@ -218,3 +218,25 @@ func Dedent(s string) string {
 	}
 	return strings.Join(lines, "\n")
 }
+
+func consumeLeft(src []byte, pos int, cond func(rune) bool) int {
+	for {
+		r, n := utf8.DecodeLastRune(src[:pos])
+		if !cond(r) {
+			break
+		}
+		pos -= n
+	}
+	return pos
+}
+
+func consumeRight(src []byte, pos int, cond func(rune) bool) int {
+	for {
+		r, n := utf8.DecodeRune(src[pos:])
+		if !cond(r) {
+			break
+		}
+		pos += n
+	}
+	return pos
+}

--- a/golang/gocode.go
+++ b/golang/gocode.go
@@ -12,14 +12,12 @@ import (
 	"kuroku.io/margocode/suggest"
 	"margo.sh/mg"
 	"margo.sh/mgpf"
-	"margo.sh/mgutil"
 	"margo.sh/sublime"
 	"os"
 	"path"
 	"strings"
 	"time"
 	"unicode"
-	"unicode/utf8"
 )
 
 var (
@@ -158,7 +156,7 @@ func (g *Gocode) RUnmount(mx *mg.Ctx) {
 func (g *Gocode) Reduce(mx *mg.Ctx) *mg.State {
 	start := time.Now()
 
-	mx, gx := initGocodeReducer(mx, *g)
+	gx := initGocodeReducer(mx, *g)
 	st := mx.State
 	if gx == nil {
 		return st
@@ -366,55 +364,35 @@ type gocodeCtx struct {
 	bctx *build.Context
 }
 
-func initGocodeReducer(mx *mg.Ctx, g Gocode) (*mg.Ctx, *gocodeCtx) {
+func initGocodeReducer(mx *mg.Ctx, g Gocode) *gocodeCtx {
 	// TODO: simplify and get rid of this func, it's only used once
 
-	st := mx.State
-	bctx := BuildContext(mx)
-	src, _ := st.View.ReadAll()
+	src, pos := mx.View.SrcPos()
 	if len(src) == 0 {
-		return mx, nil
+		return nil
 	}
-	pos := mgutil.ClampPos(src, st.View.Pos)
-
-	// move the cursor off the word.
-	// xxx.yyy| ~> xxx.|
-	// xxx| ~> |xxx
-	// this results in fetching all possible results
-	// which is desirable because the editor is usually better at filtering the list
-	for {
-		r, n := utf8.DecodeLastRune(src[:pos])
-		if !IsLetter(r) {
-			break
-		}
-		pos -= n
-	}
-	// seems legit...
-	st = st.SetView(st.View.Copy(func(v *mg.View) { v.Pos = pos }))
-	mx = mx.SetState(st)
 
 	cx := NewCursorCtx(mx, src, pos)
 	if cx.Scope.Any(PackageScope, FileScope, ImportScope, StringScope, CommentScope) {
-		return mx, nil
+		return nil
 	}
 
 	gsu := mctl.newGcSuggest(mx)
 	gsu.suggestDebug = g.Debug
-	gx := &gocodeCtx{
+	return &gocodeCtx{
 		mx:   mx,
 		gsu:  gsu,
 		cn:   cx.CursorNode,
-		fn:   st.View.Filename(),
+		fn:   mx.View.Filename(),
 		pos:  pos,
 		src:  src,
-		bctx: bctx,
+		bctx: BuildContext(mx),
 	}
-	return mx, gx
 }
 
 func (gx *gocodeCtx) suggestions() suggestions {
 	if len(gx.src) == 0 {
 		return suggestions{}
 	}
-	return gx.gsu.suggestions(gx.mx)
+	return gx.gsu.suggestions(gx.mx, gx.src, gx.pos)
 }

--- a/golang/gocode_calltips.go
+++ b/golang/gocode_calltips.go
@@ -6,11 +6,13 @@ import (
 	"go/parser"
 	"go/printer"
 	"go/token"
+	"io"
 	"kuroku.io/margocode/suggest"
 	"margo.sh/mg"
 	"margo.sh/mgutil"
 	"margo.sh/sublime"
 	"strings"
+	"unicode"
 )
 
 type gocodeCtAct struct {
@@ -74,126 +76,172 @@ func (gc *GocodeCalltips) processer() {
 func (gc *GocodeCalltips) process(act gocodeCtAct) {
 	defer func() { recover() }()
 
+	if s := gc.processStatus(act); s != act.status {
+		act.mx.Store.Dispatch(gocodeCtAct{status: s})
+	}
+}
+
+func (gc *GocodeCalltips) processStatus(act gocodeCtAct) string {
 	mx := act.mx
-	status := ""
-	defer func() {
-		if status != act.status {
-			mx.Store.Dispatch(gocodeCtAct{status: status})
-		}
-	}()
-
-	src, _ := mx.View.ReadAll()
+	src, srcPos := mx.View.SrcPos()
 	if len(src) == 0 {
-		return
+		return ""
 	}
 
-	srcPos := mgutil.ClampPos(src, mx.View.Pos)
 	cn := ParseCursorNode(nil, src, srcPos)
-	tpos := cn.TokenFile.Pos(srcPos)
-	var call *ast.CallExpr
-	for i := len(cn.Nodes) - 1; i >= 0; i-- {
-		nod := cn.Nodes[i]
-		if _, ok := nod.(*ast.BlockStmt); ok {
-			break
-		}
-		x, ok := nod.(*ast.CallExpr)
-		if !ok {
-			continue
-		}
-
-		// we found a CallExpr, but it's not necessarily the right one.
-		// in `funcF(fun|cG())` this will match funcG, but we want funcF
-		// so we track of the first CallExpr but keep searching until we find one
-		// whose left paren is before the cursor
-		if call == nil {
-			call = x
-		}
-		if x.Lparen < tpos {
-			call = x
-			break
-		}
-	}
+	tokPos := cn.TokenFile.Pos(srcPos)
+	call, assign := gc.findCallExpr(cn.Nodes, tokPos)
 	if call == nil {
-		return
+		return ""
 	}
 
 	ident := gc.exprIdent(call.Fun)
 	if ident == nil {
-		return
+		return ""
 	}
 
-	funcName := ident.String()
-	idPos := cn.TokenFile.Position(ident.End()).Offset
-	candidate, ok := gc.candidate(mx, src, idPos, funcName)
+	fxName := ident.String()
+	candidate, ok := gc.candidate(mx, src, cn.TokenFile.Position(ident.End()).Offset, fxName)
 	if !ok {
-		return
+		return ""
 	}
 
-	x, _ := parser.ParseExpr(candidate.Type)
-	fx, _ := x.(*ast.FuncType)
+	expr, _ := parser.ParseExpr(candidate.Type)
+	fx, _ := expr.(*ast.FuncType)
 	if fx == nil {
-		return
+		return ""
 	}
 
-	status = gc.funcSrc(fx, gc.argPos(call, tpos), funcName)
+	var highlight ast.Node
+	switch {
+	case call.Lparen < tokPos && tokPos <= call.Rparen:
+		i := gc.selectedFieldExpr(cn.TokenFile.Offset, src, srcPos, call.Args)
+		highlight = gc.selectedFieldName(fx.Params, i)
+	case assign != nil:
+		i := gc.selectedFieldExpr(cn.TokenFile.Offset, src, srcPos, assign.Lhs)
+		highlight = gc.selectedFieldName(fx.Results, i)
+	}
+
+	return gc.funcSrc(fx, fxName, highlight)
 }
 
-func (gc *GocodeCalltips) funcSrc(fx *ast.FuncType, argPos int, funcName string) string {
-	fset := token.NewFileSet()
-	buf := &bytes.Buffer{}
-	buf.WriteString("func ")
-	buf.WriteString(funcName)
-	buf.WriteString("(")
-	fieldPos := 0
-	for inField, field := range fx.Params.List {
-		for _, name := range field.Names {
-			if fieldPos > 0 {
-				buf.WriteString(", ")
+func (gc *GocodeCalltips) findCallExpr(nodes []ast.Node, pos token.Pos) (*ast.CallExpr, *ast.AssignStmt) {
+	var assign *ast.AssignStmt
+	var call, callCandidate *ast.CallExpr
+out:
+	for i := len(nodes) - 1; i >= 0; i-- {
+		switch x := nodes[i].(type) {
+		case *ast.BlockStmt:
+			break out
+		case *ast.AssignStmt:
+			assign = x
+		case *ast.CallExpr:
+			// we found a CallExpr, but it's not necessarily the right one.
+			// in `funcF(fun|cG())` this will match funcG, but we want funcF
+			// so we track of the first CallExpr but keep searching until we find one
+			// whose left paren is before the cursor
+			if callCandidate == nil {
+				callCandidate = x
 			}
-			fieldPos++
-
-			if inField == argPos {
-				buf.WriteString("⎨")
-			}
-			buf.WriteString(name.String())
-			buf.WriteString(" ")
-			printer.Fprint(buf, fset, field.Type)
-			if inField == argPos {
-				buf.WriteString("⎬")
+			if x.Lparen < pos {
+				call = x
+				break out
 			}
 		}
 	}
-	buf.WriteString(")")
 
-	if fl := fx.Results; fl != nil {
-		buf.WriteString(" ")
-		hasNames := len(fl.List) != 0 && len(fl.List[0].Names) != 0
-		if hasNames {
-			buf.WriteString("(")
+	switch {
+	case call != nil:
+		return call, nil
+	case callCandidate != nil:
+		return callCandidate, nil
+	case assign != nil && len(assign.Rhs) == 1:
+		if call, ok := assign.Rhs[0].(*ast.CallExpr); ok {
+			return call, assign
 		}
-		printFields(buf, fset, fl.List, true)
-		if hasNames {
-			buf.WriteString(")")
-		}
+	}
+	return nil, nil
+}
+
+func (gc *GocodeCalltips) funcSrc(fx *ast.FuncType, funcName string, highlight ast.Node) string {
+	fset := token.NewFileSet()
+	buf := &bytes.Buffer{}
+
+	buf.WriteString("func ")
+	buf.WriteString(funcName)
+
+	var params []*ast.Field
+	if p := fx.Params; p != nil {
+		params = p.List
+	}
+	fieldPrinter{
+		fset:      fset,
+		fields:    params,
+		output:    buf,
+		parens:    true,
+		names:     true,
+		types:     true,
+		highlight: highlight,
+	}.print()
+
+	if p := fx.Results; p != nil {
+		buf.WriteByte(' ')
+		fieldPrinter{
+			fset:      fset,
+			fields:    p.List,
+			output:    buf,
+			parens:    len(p.List) != 0 && len(p.List[0].Names) != 0,
+			names:     true,
+			types:     true,
+			highlight: highlight,
+		}.print()
 	}
 
 	return buf.String()
 }
 
-func (gc *GocodeCalltips) argPos(call *ast.CallExpr, tpos token.Pos) int {
-	np := token.NoPos
-	ne := token.NoPos
-	for i, a := range call.Args {
-		if np == token.NoPos {
-			np = a.Pos()
+func (gc *GocodeCalltips) selectedFieldName(fl *ast.FieldList, fieldIndex int) ast.Node {
+	if fl == nil || len(fl.List) == 0 {
+		return nil
+	}
+
+	index := 0
+	for _, field := range fl.List {
+		if len(field.Names) == 0 {
+			if index == fieldIndex {
+				return field
+			}
+			index++
+			continue
 		}
-		ne = a.End()
-		if np <= tpos && tpos <= ne {
+
+		for _, id := range field.Names {
+			if index == fieldIndex {
+				return id
+			}
+			index++
+		}
+	}
+
+	f := fl.List[len(fl.List)-1]
+	if _, ok := f.Type.(*ast.Ellipsis); ok && len(f.Names) == 1 {
+		return f.Names[0]
+	}
+
+	return nil
+}
+
+func (gc *GocodeCalltips) selectedFieldExpr(offset func(token.Pos) int, src []byte, pos int, fields []ast.Expr) int {
+	for i, a := range fields {
+		np := consumeLeft(src, offset(a.Pos()), unicode.IsSpace)
+		ne := consumeRight(src, offset(a.End()), unicode.IsSpace)
+		if np <= pos && pos <= ne {
 			return i
 		}
-		np = a.End() + 1
 	}
-	return -1
+	// in most cases we're after a comma,
+	// so choose the next field (that doesn't exist yet)
+	return len(fields)
 }
 
 func (gc *GocodeCalltips) candidate(mx *mg.Ctx, src []byte, pos int, funcName string) (candidate suggest.Candidate, ok bool) {
@@ -201,18 +249,21 @@ func (gc *GocodeCalltips) candidate(mx *mg.Ctx, src []byte, pos int, funcName st
 		return candidate, false
 	}
 
-	mx = mx.SetView(mx.View.Copy(func(v *mg.View) {
-		v.Pos = pos
-	}))
 	gsu := mctl.newGcSuggest(mx)
 	gsu.suggestDebug = gc.Debug
-	sugg := gsu.suggestions(mx)
+	sugg := gsu.suggestions(mx, src, pos)
 	for _, c := range sugg.candidates {
-		if strings.HasPrefix(c.Type, "func(") && strings.EqualFold(funcName, c.Name) {
+		if !strings.HasPrefix(c.Type, "func(") {
+			continue
+		}
+		switch {
+		case funcName == c.Name:
 			return c, true
+		case strings.EqualFold(funcName, c.Name):
+			candidate = c
 		}
 	}
-	return candidate, false
+	return candidate, candidate != suggest.Candidate{}
 }
 
 func (gc *GocodeCalltips) exprIdent(x ast.Expr) *ast.Ident {
@@ -223,4 +274,68 @@ func (gc *GocodeCalltips) exprIdent(x ast.Expr) *ast.Ident {
 		return x.Sel
 	}
 	return nil
+}
+
+type fieldPrinter struct {
+	fset      *token.FileSet
+	fields    []*ast.Field
+	output    io.Writer
+	names     bool
+	types     bool
+	parens    bool
+	highlight ast.Node
+}
+
+func (p fieldPrinter) print() {
+	if p.parens {
+		p.output.Write([]byte("("))
+	}
+
+	hlId, _ := p.highlight.(*ast.Ident)
+	hlField, _ := p.highlight.(*ast.Field)
+	hlWriteOpen := func() { p.output.Write([]byte("⎨")) }
+	hlWriteClose := func() { p.output.Write([]byte("⎬")) }
+
+	for i, f := range p.fields {
+		if i > 0 {
+			p.output.Write([]byte(", "))
+		}
+
+		if f == hlField {
+			hlWriteOpen()
+		}
+
+		var names []*ast.Ident
+		if p.names {
+			names = f.Names
+		}
+		for j, id := range names {
+			if j > 0 {
+				p.output.Write([]byte(", "))
+			}
+			if hlId == id {
+				hlWriteOpen()
+			}
+			p.output.Write([]byte(id.String()))
+
+			if hlId == id && j < len(names)-1 {
+				hlWriteClose()
+			}
+		}
+
+		if p.types {
+			if len(names) != 0 {
+				p.output.Write([]byte(" "))
+			}
+			printer.Fprint(p.output, p.fset, f.Type)
+		}
+
+		if l := names; f == hlField || (len(l) > 0 && l[len(l)-1] == hlId) {
+			hlWriteClose()
+		}
+	}
+
+	if p.parens {
+		p.output.Write([]byte(")"))
+	}
 }


### PR DESCRIPTION
* GocodeCalltips: add support for assignments

* GocodeCalltips: highlight the desired arg in `fx(|)` and `fx(1,|)`

* GocodeCalltips: prefer exact matches

    this makes `fx(|)` match the correct function definition in:

        package main

        func main() {
            fx(|)
            fx := Fx
            fx(|)
        }

        func fx(s string) {}
        func Fx(i, j int) {}

* make all gocode suggestions use non-partials mode by default

* fix the golang.Gocode{} reducer changing View.Pos