### PR TITLE
Use a code-generation strategy to add imports

### DIFF
--- a/golang/gocode.go
+++ b/golang/gocode.go
@@ -61,8 +61,8 @@ func (gr *gocodeReq) addUnimportedPkg(st *mg.State, p impSpec) *mg.State {
 		p.Name = ""
 	}
 
-	s, ok := updateImports(st.View.Filename(), src, impSpecList{p}, nil)
-	if ok {
+	s, merged, _ := impSpecList{p}.mergeWithSrc(st.View.Filename(), src)
+	if len(merged) != 0 {
 		st = st.SetViewSrc(s)
 	}
 


### PR DESCRIPTION
Use a code-generation strategy instead of modifying the AST when adding imports.
The latter is a too unreliable when there are comments involved.
This should fix DisposaBoy/GoSublime#904 completely.